### PR TITLE
fix(deps): update axios to 1.8.2 for CVE-2025-27152

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@tsparticles/react": "^3.0.0",
     "@types/lodash": "^4.17.0",
     "antd": "^5.17.4",
-    "axios": "^1.6.8",
+    "axios": "^1.8.2",
     "clsx": "^2.1.0",
     "cookie": "^0.6.0",
     "cookies-next": "^5.1.0",


### PR DESCRIPTION
## Summary
- Update `axios` to `1.8.2`.
- Addresses `CVE-2025-27152`.

## Context
Update axios to version 1.8.2 or later.

## Validation
- Run the repository test suite after the dependency bump.